### PR TITLE
Removal of Popup Hack & Webcentric

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,11 @@
         <p class="who">Developers</p>
         <p class="when">Third Thursday</p>
         </li>
+        <li class="pythonglasgow vcard">
+        <h3><a class="fn org url" href="http://pythonglasgow.org/">Python Glasgow</a></h3>
+        <p class="who">Pythonistas</p>
+        <p class="when">Fourth Monday</p>
+        </li>
         <li class="techmeetup vcard">
         <h3><a class="fn org url" href="http://techmeetup.co.uk">Techmeetup</a></h3>
         <p class="who">Technologists</p>

--- a/public/stylesheets/core.css
+++ b/public/stylesheets/core.css
@@ -180,3 +180,7 @@ form h5 {
 .events .leanagile {
 	border-color: Maroon;
 }
+
+.events .pythonglasgow {
+    border-color: #FFBC29;
+}


### PR DESCRIPTION
- Webcentric is dead. 
- Popup Hack is either dead, needing a new organiser or on a break. If it does make a come-back I'll add it back in
