### PR TITLE
Python Glasgow Update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,11 @@
         <p class="who">UX/UI designers</p>
         <p class="when">Second Monday</p>
         </li>
+        <li class="pythonglasgow vcard">
+        <h3><a class="fn org url" href="http://www.popuphack.co.uk/">Python Glasgow</a></h3>
+        <p class="who">Pythonistas</p>
+        <p class="when">Second Tuesday</p>
+        </li>
         <li class="leanagile vcard">
         <h3><a class="fn org url" href="http://www.meetup.com/Lean-Agile-Glasgow/">Lean Agile Glasgow</a></h3>
         <p class="who">Agilists &amp; lean thinkers</p>
@@ -46,11 +51,6 @@
         <h3><a class="fn org url" href="http://twitter.com/#!/refreshgla">Refresh Glasgow</a></h3>
         <p class="who">Developers + Designers</p>
         <p class="when">Third Wednesday</p>
-        </li>
-        <li class="pythonglasgow vcard">
-        <h3><a class="fn org url" href="http://pythonglasgow.org/">Python Glasgow</a></h3>
-        <p class="who">Pythonistas</p>
-        <p class="when">Fourth Monday</p>
         </li>
         <li class="techmeetup vcard">
         <h3><a class="fn org url" href="http://techmeetup.co.uk">Techmeetup</a></h3>


### PR DESCRIPTION
Python Glasgow now runs on the second Tuesday.
Confirmed on http://pythonglasgow.org/
